### PR TITLE
Fixed favicon href path

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -10,7 +10,7 @@ export default function MyApp({ Component, pageProps }) {
     <>
       <Head>
         <title>Contentlayer Next.js Example</title>
-        <link rel="icon" type="image/x-icon" href="/favicon.png" />
+        <link rel="icon" type="image/x-icon" href="/images/favicon.png" />
       </Head>
 
       <Header />


### PR DESCRIPTION
Stops 404 for favicon file in the console.

- Changed the favicon path from /favicon.png to /images/favicon.png