### PR TITLE
run `contentlayer build` prior to `next build` in package.json

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,5 +1,5 @@
 tasks:
-  - init: yarn install && yarn contentlayer build
+  - init: yarn install
     command: gp open posts/change-me.md && yarn dev
 
 ports:

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "contentlayer build && next build",
     "start": "next start"
   },
   "dependencies": {


### PR DESCRIPTION
See https://github.com/contentlayerdev/website/pull/106, https://github.com/contentlayerdev/website/issues/105

Putting the `contentlayer build` in package.json should make it easier for someone to clone this repo and deploy to an environment other than Gitpod

Note:
- I didn't actually check that this works on Gitpod, I'm hoping there will be CI for that
- It's probable that the build may fail due to https://github.com/contentlayerdev/contentlayer/issues/506, but I suppose that's totally unrelated to this PR